### PR TITLE
[FIX] stop looking for modules in cwd

### DIFF
--- a/gtk/gtkmodules.c
+++ b/gtk/gtkmodules.c
@@ -297,13 +297,8 @@ find_module (const gchar *name)
   gchar *module_name;
 
   module_name = _gtk_find_module (name, "modules");
-  if (!module_name)
-    {
-      /* As last resort, try loading without an absolute path (using system
-       * library path)
-       */
-      module_name = module_build_path (NULL, name);;
-    }
+  if (module_name == NULL)
+    return NULL;
 
   module = g_module_open (module_name, G_MODULE_BIND_LOCAL | G_MODULE_BIND_LAZY);
 


### PR DESCRIPTION
I found this when trying to make a Arch package of stefan11111 gtk2 fork. The AUR package for GTK2 applied this patch that comes from upstream GNOME https://aur.archlinux.org/cgit/aur.git/tree/0002-Stop-looking-for-modules-in-cwd.patch 

CVE-2024-6655: https://www.openwall.com/lists/oss-security/2024/09/09/1
https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7361