### PR TITLE
[FIX] Lower severity of XID collision warnings

### DIFF
--- a/gdk/x11/gdkxid.c
+++ b/gdk/x11/gdkxid.c
@@ -58,7 +58,7 @@ _gdk_xid_table_insert (GdkDisplay *display,
 					    (GEqualFunc) gdk_xid_equal);
 
   if (g_hash_table_lookup (display_x11->xid_ht, xid))
-    g_warning ("XID collision, trouble ahead");
+    g_debug ("XID collision, trouble ahead");
 
   g_hash_table_insert (display_x11->xid_ht, xid, data);
 }


### PR DESCRIPTION
Another patch that Arch maintainers applied to their GTK2 before it got AURed